### PR TITLE
Fixed DMP scope to include project and dataset. 

### DIFF
--- a/examples/JSON/ex2-dataset-planned.json
+++ b/examples/JSON/ex2-dataset-planned.json
@@ -1,34 +1,26 @@
 {
-	"DMP": {
-	
-			"title": "DMP in a planning phase",
-			"description": "Examaple of a DMP describing a project in which source code will be created and put on GitHub. The DMP  is created on 2019-02-22. The code is planned to be released on 2019-06-30 using CC-BY license.",
-	 
-	
-		"created": "2019-02-22T13:20:15.5",
-		"modified": "2019-02-22T13:20:15.5"
-	},
-
-	"project": {},
-
-	"dataset": {
-		"title": "Source Code",
-		"description": "Proof of concept implementation",
-		"type": "source-code",
-		"issued": "2019-06-30",
-		"personalData": "unknown",
-		"sensitiveData": "no",
-
-		"distribution": {
-			"title": "Java code",
-			"accessURL": "http://github.com/some-repo...",
-			"dataAccess": "open",
-
-			"license": {
-				"license_ref": "https://creativecommons.org/licenses/by/4.0/",
-				"startDate": "2019-06-30"
-			}
-		}
-	}
-
+    "DMP": {
+        "title": "DMP in a planning phase",
+        "description": "Examaple of a DMP describing a project in which source code will be created and put on GitHub. The DMP  is created on 2019-02-22. The code is planned to be released on 2019-06-30 using CC-BY license.",
+        "created": "2019-02-22T13:20:15.5",
+        "modified": "2019-02-22T13:20:15.5",
+        "project": {},
+        "dataset": {
+            "title": "Source Code",
+            "description": "Proof of concept implementation",
+            "type": "source-code",
+            "issued": "2019-06-30",
+            "personalData": "unknown",
+            "sensitiveData": "no",
+            "distribution": {
+                "title": "Java code",
+                "accessURL": "http://github.com/some-repo...",
+                "dataAccess": "open",
+                "license": {
+                    "license_ref": "https://creativecommons.org/licenses/by/4.0/",
+                    "startDate": "2019-06-30"
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION


Note that in the original file, the DMP scope stops after the "modified" attribute. As such, the DMP entity does not "contain" the dataset entity. 

The reformating was maybe a poor idea (it obscures the change), but the only significant change is the move of the closing brace to the end of the file. 

In the new version, the closing brace of the DMP has been moved at the end of the file to include the dataset. The DMP scope is now consistent with other examples available in the repository.