### PR TITLE
Added example with minimal DMP based on model diagram

### DIFF
--- a/examples/JSON/ex8-dmp-minimal-content.json
+++ b/examples/JSON/ex8-dmp-minimal-content.json
@@ -1,0 +1,27 @@
+{
+    "DMP": {
+        "title": "Minimal DMP",
+        "language": "en",
+
+        "created": "2018-07-23T10:10:23.6",
+        "modified": "2019-02-06T10:10:23.6",
+
+        "ethical_issues_exist": "unknown",
+
+        "contact": {
+            "mail": "cc@example.com",
+            "name": "Charlie Chaplin",
+            "contact_id": {
+                "contact_id": "http://orcid.org/0000-0000-0000-0000",
+                "contact_id_type": "HTTP-ORCID"
+            }
+        },
+
+        "dataset": {
+            "title": "Placeholder dataset",
+            "type": "(value from dictionary)",
+            "personalData": "unknown",
+            "sensitiveData": "unknown"
+        }
+    }
+}


### PR DESCRIPTION
I created the smallest possible DMP instance based on the information contained in the LucidChart diagram. 

Based on this example, any instance of the model that does not contain at least the information contained in this example is incomplete with respect to the model. 

If the model is updated (mandatory field and/or relationship) this instance will need to be updated as well. 

