### PR TITLE
Remove tab from ex2-dataset-planned.json

### DIFF
--- a/examples/JSON/ex2-dataset-planned.json
+++ b/examples/JSON/ex2-dataset-planned.json
@@ -1,7 +1,7 @@
 {
 	"dmp": {
 		"title": "DMP in a planning phase",
-		"description": "Example of a DMP describing a project in which source code will be created and put on GitHub. The DMP	is created on 2019-02-22. The code is planned to be released on 2019-06-30 using CC-BY license.",
+		"description": "Example of a DMP describing a project in which source code will be created and put on GitHub. The DMP is created on 2019-02-22. The code is planned to be released on 2019-06-30 using CC-BY license.",
 		"created": "2019-02-22T13:20:15.5",
 		"modified": "2019-02-22T13:20:15.5",
 		"project": [],


### PR DESCRIPTION
There is a tab in one of the JSON example files, which, as I just learned, is not allowed in JSON.